### PR TITLE
Fix alignment within the menubar

### DIFF
--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -17,7 +17,11 @@
 -(void)timerFired:(id)notused
 {
     statusItem.menu=self.menu;
-    statusItem.button.image=self.image;
+    NSImage*canvas=[[NSImage alloc] initWithSize:NSMakeSize(self.length, self.view.frame.size.height)];
+    [canvas lockFocus];
+    [self.view drawRect:NSMakeRect(0, 0, canvas.size.width, canvas.size.height)];
+    [canvas unlockFocus];
+    statusItem.button.image=canvas;
 }
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval
 {


### PR DESCRIPTION
Since the NSMenuExtraView drawRect methods wasn't being called, the alignment issues fixed within them wasn't being used.

For an example see [`- (void)drawRect:(NSRect)` within `MenuMeterCPUView`](https://github.com/yujitach/MenuMeters/blob/master/MenuExtras/MenuMeterCPU/MenuMeterCPUView.m#L70-L71)


The way this problem has been solved isn't optimal, but at least it it seems to work and doesn't break backwards compatibility with earlier OSes.

Note: If you're not seeing a problem I recommend using the CPU meter in thermometer mode. 