### PR TITLE
Remove appearanceClass to fix darkmode

### DIFF
--- a/Common/MenuMeterWorkarounds.m
+++ b/Common/MenuMeterWorkarounds.m
@@ -136,15 +136,6 @@ __private_extern__ BOOL IsMenuMeterMenuBarDarkThemed(void) {
     if (interfaceStyle && [interfaceStyle isEqualToString:@"Dark"]) {
 		isDark = YES;
 	}
-	Class appearanceClass = NSClassFromString(@"NSAppearance");
-	if (appearanceClass && [appearanceClass respondsToSelector:@selector(currentAppearance)]) {
-		id currentAppearance = [appearanceClass performSelector:@selector(currentAppearance)];
-		if (currentAppearance && [currentAppearance respondsToSelector:@selector(name)]) {
-			if ([[currentAppearance name] hasPrefix:@"NSAppearanceNameVibrantDark"]) {
-				isDark = YES;
-			}
-		}
-	}
 	return isDark;
 } // IsMenuMeterMenuBarDarkThemed
 


### PR DESCRIPTION
Fix for issue: https://github.com/yujitach/MenuMeters/issues/22

Removes `appearanceClass` where logic was falsely identifying as dark mode after dark mode switched off.

While `interfaceStyle` is still undocumented (AFAIK), it seems sufficient for dark mode control now.