### PR TITLE
Halve MenuMeters CPU/energy usage

### DIFF
--- a/Common/MenuMeterDefaults.m
+++ b/Common/MenuMeterDefaults.m
@@ -121,7 +121,6 @@
 ///////////////////////////////////////////////////////////////
 
 - (double)cpuInterval {
-    return 0.05f;
 	return [self loadDoublePref:kCPUIntervalPref
 					   lowBound:kCPUUpdateIntervalMin
 					  highBound:kCPUUpdateIntervalMax
@@ -378,7 +377,6 @@
 ///////////////////////////////////////////////////////////////
 
 - (double)netInterval {
-    return 0.05f;
 	return [self loadDoublePref:kNetIntervalPref
 					   lowBound:kNetUpdateIntervalMin
 					  highBound:kNetUpdateIntervalMax

--- a/Common/MenuMeterDefaults.m
+++ b/Common/MenuMeterDefaults.m
@@ -121,6 +121,7 @@
 ///////////////////////////////////////////////////////////////
 
 - (double)cpuInterval {
+    return 0.05f;
 	return [self loadDoublePref:kCPUIntervalPref
 					   lowBound:kCPUUpdateIntervalMin
 					  highBound:kCPUUpdateIntervalMax
@@ -377,6 +378,7 @@
 ///////////////////////////////////////////////////////////////
 
 - (double)netInterval {
+    return 0.05f;
 	return [self loadDoublePref:kNetIntervalPref
 					   lowBound:kNetUpdateIntervalMin
 					  highBound:kNetUpdateIntervalMax

--- a/Common/MenuMeterDefaults.m
+++ b/Common/MenuMeterDefaults.m
@@ -836,21 +836,15 @@
 - (int)loadIntPref:(NSString *)prefName lowBound:(int)lowBound
 		  highBound:(int)highBound defaultValue:(int)defaultValue {
 
-	int returnVal = defaultValue;
-	NSNumber *prefValue = (NSNumber *)CFPreferencesCopyValue((CFStringRef)prefName,
-															 (CFStringRef)kMenuMeterDefaultsDomain,
-															 kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-	if (prefValue && [prefValue isKindOfClass:[NSNumber class]]) {
-		returnVal = [prefValue intValue];
-		if ((returnVal < lowBound) || (returnVal > highBound)) {
-			returnVal = defaultValue;
-			[self saveIntPref:prefName value:returnVal];
-		}
-	} else {
-		[self saveIntPref:prefName value:returnVal];
+	Boolean keyExistsAndHasValidFormat = NO;
+	CFIndex returnValue = CFPreferencesGetAppIntegerValue((CFStringRef)prefName,
+														  (CFStringRef)kMenuMeterDefaultsDomain,
+														  &keyExistsAndHasValidFormat);
+	if (!keyExistsAndHasValidFormat) {
+		[self saveIntPref:prefName value:defaultValue];
+		returnValue = defaultValue;
 	}
-	if (prefValue) CFRelease(prefValue);
-	return returnVal;
+	return (int) returnValue;
 
 } // _loadIntPref
 
@@ -865,21 +859,21 @@
 - (int)loadBitFlagPref:(NSString *)prefName validFlags:(int)flags
 			  zeroValid:(BOOL)zeroValid defaultValue:(int)defaultValue {
 
-	int returnVal = defaultValue;
-	NSNumber *prefValue = (NSNumber *)CFPreferencesCopyValue((CFStringRef)prefName,
-															 (CFStringRef)kMenuMeterDefaultsDomain,
-															 kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-	if (prefValue && [prefValue isKindOfClass:[NSNumber class]]) {
-		returnVal = [prefValue intValue];
-		if (((returnVal | flags) != flags) || (zeroValid && !returnVal)) {
-			returnVal = defaultValue;
-			[self saveBitFlagPref:prefName value:returnVal];
+	Boolean keyExistsAndHasValidFormat = NO;
+	CFIndex returnValue = CFPreferencesGetAppIntegerValue((CFStringRef)prefName,
+														  (CFStringRef)kMenuMeterDefaultsDomain,
+														  &keyExistsAndHasValidFormat);
+	if (keyExistsAndHasValidFormat) {
+		if (((returnValue | flags) != flags) || (zeroValid && !returnValue)) {
+			keyExistsAndHasValidFormat = NO;
 		}
-	} else {
-		[self saveBitFlagPref:prefName value:returnVal];
 	}
-	if (prefValue) CFRelease(prefValue);
-	return returnVal;
+	
+	if (!keyExistsAndHasValidFormat) {
+		[self saveIntPref:prefName value:defaultValue];
+		returnValue = defaultValue;
+	}
+	return (int) returnValue;
 
 } // _loadBitFlagPref
 
@@ -893,16 +887,14 @@
 
 - (BOOL)loadBoolPref:(NSString *)prefName defaultValue:(BOOL)defaultValue {
 
-	BOOL returnValue = defaultValue;
-	NSObject *prefValue = (NSObject *)CFPreferencesCopyValue((CFStringRef)prefName,
-															 (CFStringRef)kMenuMeterDefaultsDomain,
-															 kCFPreferencesCurrentUser, kCFPreferencesAnyHost);
-	if (prefValue && [prefValue respondsToSelector:@selector(boolValue)]) {
-		returnValue = [(NSNumber *)prefValue boolValue];
-	} else {
+	Boolean keyExistsAndHasValidFormat = NO;
+	BOOL returnValue = CFPreferencesGetAppBooleanValue((CFStringRef)prefName,
+													   (CFStringRef)kMenuMeterDefaultsDomain,
+													   &keyExistsAndHasValidFormat);
+	if (!keyExistsAndHasValidFormat) {
 		[self saveBoolPref:prefName value:defaultValue];
+		returnValue = defaultValue;
 	}
-	if (prefValue) CFRelease(prefValue);
 	return returnValue;
 
 } // _loadBoolPref

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.h
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.h
@@ -39,10 +39,6 @@
 	// Menu Extra necessities
 	NSMenu 							*extraMenu;
     MenuMeterCPUView 				*extraView;
-	// Is this Panther?
-	BOOL							isPantherOrLater;
-	// The timer
-	NSTimer							*updateTimer;
 	// Prefs object
 	MenuMeterDefaults				*ourPrefs;
 	// Info gatherers

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -351,15 +351,18 @@
 		}
 
 		// Get load at this position.
-		float system = [[[loadHistoryEntry objectAtIndex:processor] objectForKey:@"system"] floatValue];
-		float user = [[[loadHistoryEntry objectAtIndex:processor] objectForKey:@"user"] floatValue];
+        MenuMeterCPULoad *load = loadHistoryEntry[processor];
+        float system = load.system;
+        float user = load.user;
 		if ([ourPrefs cpuAvgAllProcs]) {
-			for (uint32_t cpuNum = 1; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
-				system += [[[loadHistoryEntry objectAtIndex:cpuNum] objectForKey:@"system"] floatValue];
-				user += [[[loadHistoryEntry objectAtIndex:cpuNum] objectForKey:@"user"] floatValue];
+            NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+			for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
+                MenuMeterCPULoad *load = loadHistoryEntry[cpuNum];
+                system += load.system;
+                user += load.user;
 			}
-			system /= [cpuInfo numberOfCPUs];
-			user /= [cpuInfo numberOfCPUs];
+			system /= numberOfCPUs;
+			user /= numberOfCPUs;
 		}
 		// Sanity and limit
 		if (system < 0) system = 0;
@@ -397,14 +400,15 @@
 	NSArray *currentLoad = [loadHistory lastObject];
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
-	float totalLoad = [[[currentLoad objectAtIndex:processor] objectForKey:@"system"] floatValue] +
-						[[[currentLoad objectAtIndex:processor] objectForKey:@"user"] floatValue];
+    MenuMeterCPULoad *load = currentLoad[processor];
+    float totalLoad = load.system + load.user;
 	if ([ourPrefs cpuAvgAllProcs]) {
-		for (uint32_t cpuNum = 1; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
-			totalLoad += [[[currentLoad objectAtIndex:cpuNum] objectForKey:@"system"] floatValue] +
-							[[[currentLoad objectAtIndex:cpuNum] objectForKey:@"user"] floatValue];
+        NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+		for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
+            MenuMeterCPULoad *load = currentLoad[cpuNum];
+            totalLoad += load.user + load.system;
 		}
-		totalLoad /= [cpuInfo numberOfCPUs];
+		totalLoad /= numberOfCPUs;
 	}
 	if (totalLoad > 1) totalLoad = 1;
 	if (totalLoad < 0) totalLoad = 0;
@@ -434,15 +438,18 @@
 	NSArray *currentLoad = [loadHistory lastObject];
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
-	float system = [[[currentLoad objectAtIndex:processor] objectForKey:@"system"] floatValue];
-	float user = [[[currentLoad objectAtIndex:processor] objectForKey:@"user"] floatValue];
+    MenuMeterCPULoad *load = currentLoad[processor];
+    float system = load.system;
+    float user = load.user;
 	if ([ourPrefs cpuAvgAllProcs]) {
-		for (uint32_t cpuNum = 1; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
-			system += [[[currentLoad objectAtIndex:cpuNum] objectForKey:@"system"] floatValue];
-			user += [[[currentLoad objectAtIndex:cpuNum] objectForKey:@"user"] floatValue];
+        NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+		for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
+            MenuMeterCPULoad *load = currentLoad[cpuNum];
+            system += load.system;
+            user += load.user;
 		}
-		system /= [cpuInfo numberOfCPUs];
-		user /= [cpuInfo numberOfCPUs];
+		system /= numberOfCPUs;
+		user /= numberOfCPUs;
 	}
 	if (system > 1) system = 1;
 	if (system < 0) system = 0;
@@ -478,15 +485,18 @@
 	NSArray *currentLoad = [loadHistory lastObject];
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
-	float system = [[[currentLoad objectAtIndex:processor] objectForKey:@"system"] floatValue];
-	float user = [[[currentLoad objectAtIndex:processor] objectForKey:@"user"] floatValue];
+    MenuMeterCPULoad *load = currentLoad[processor];
+    float system = load.system;
+    float user = load.user;
 	if ([ourPrefs cpuAvgAllProcs]) {
-		for (uint32_t cpuNum = 1; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
-			system += [[[currentLoad objectAtIndex:cpuNum] objectForKey:@"system"] floatValue];
-			user += [[[currentLoad objectAtIndex:cpuNum] objectForKey:@"user"] floatValue];
-		}
-		system /= [cpuInfo numberOfCPUs];
-		user /= [cpuInfo numberOfCPUs];
+        NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+        for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
+            MenuMeterCPULoad *load = currentLoad[cpuNum];
+            system += load.system;
+            user += load.user;
+        }
+        system /= numberOfCPUs;
+        user /= numberOfCPUs;
 	}
 	if (system > 1) system = 1;
 	if (system < 0) system = 0;
@@ -571,11 +581,12 @@
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
 	double totalLoad = 0;
-	for (uint32_t cpuNum = 0; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
-		totalLoad += [[[currentLoad objectAtIndex:cpuNum] objectForKey:@"system"] doubleValue] +
-						[[[currentLoad objectAtIndex:cpuNum] objectForKey:@"user"] doubleValue];
-	}
-	totalLoad /= [cpuInfo numberOfCPUs];
+    NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+    for (uint32_t cpuNum = 0; cpuNum < numberOfCPUs; cpuNum++) {
+        MenuMeterCPULoad *load = currentLoad[cpuNum];
+        totalLoad += load.system + load.user;
+    }
+    totalLoad /= numberOfCPUs;
 	if (totalLoad > 1) totalLoad = 1;
 	if (totalLoad < 0) totalLoad = 0;
 

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -792,24 +792,26 @@
 
 	// Restart the timer
 	[updateTimer invalidate];  // Runloop releases and retains the next one
-	updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs cpuInterval]
-												   target:self
-												 selector:@selector(updateCPUActivityDisplay:)
-												 userInfo:nil
-												  repeats:YES];
-	// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
-	if (isPantherOrLater) {
-		[[NSRunLoop currentRunLoop] addTimer:updateTimer
-									 forMode:NSEventTrackingRunLoopMode];
+	
+	if([ourPrefs loadBoolPref:kCPUMenuBundleID defaultValue:YES]) {
+		updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs cpuInterval]
+													   target:self
+													 selector:@selector(updateCPUActivityDisplay:)
+													 userInfo:nil
+													  repeats:YES];
+		// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
+		if (isPantherOrLater) {
+			[[NSRunLoop currentRunLoop] addTimer:updateTimer
+										 forMode:NSEventTrackingRunLoopMode];
+		}
+		
+		// Resize the view
+		[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
+		[self setLength:menuWidth];
+		
+		// Flag us for redisplay
+		[extraView setNeedsDisplay:YES];
 	}
-
-	// Resize the view
-	[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
-	[self setLength:menuWidth];
-
-	// Flag us for redisplay
-	[extraView setNeedsDisplay:YES];
-
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -269,16 +269,17 @@
 
 	// Loop by processor
 	float renderOffset = 0;
+    int cpuDisplayModePrefs = [ourPrefs cpuDisplayMode];
 	for (uint32_t cpuNum = 0; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
 
 		// Render graph if needed
-		if ([ourPrefs cpuDisplayMode] & kCPUDisplayGraph) {
+		if (cpuDisplayModePrefs & kCPUDisplayGraph) {
 			[self renderHistoryGraphIntoImage:currentImage forProcessor:cpuNum atOffset:renderOffset];
 			// Adjust render offset
 			renderOffset += [ourPrefs cpuGraphLength];
 		}
 		// Render percent if needed
-		if ([ourPrefs cpuDisplayMode] & kCPUDisplayPercent) {
+		if (cpuDisplayModePrefs & kCPUDisplayPercent) {
 			if ([ourPrefs cpuPercentDisplay] == kCPUPercentDisplaySplit) {
 				[self renderSplitPercentIntoImage:currentImage forProcessor:cpuNum atOffset:renderOffset];
 			} else {
@@ -286,7 +287,7 @@
 			}
 			renderOffset += percentWidth;
 		}
-		if ([ourPrefs cpuDisplayMode] & kCPUDisplayThermometer) {
+		if (cpuDisplayModePrefs & kCPUDisplayThermometer) {
 			[self renderThermometerIntoImage:currentImage forProcessor:cpuNum atOffset:renderOffset];
 			renderOffset += kCPUThermometerDisplayWidth;
 		}
@@ -552,8 +553,7 @@
 	[extraView setNeedsDisplay:YES];
 
 	// If the menu is down force it to update
-	if ([self isMenuDown] || 
-		([self respondsToSelector:@selector(isMenuDownForAX)] && [self isMenuDownForAX])) {
+	if (self.isMenuVisible) {
 		[self updateMenuWhenDown];
 	}
 

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -181,12 +181,12 @@
 	[menuItem setTarget:self];
 
 	// Get our view
-    extraView = [[MenuMeterCPUView alloc] initWithFrame:[[self view] frame] menuExtra:self];
+	extraView = [[MenuMeterCPUView alloc] initWithFrame:[[self view] frame] menuExtra:self];
 	if (!extraView) {
 		[self release];
 		return nil;
 	}
-    [self setView:extraView];
+	[self setView:extraView];
 
 	// Register for pref changes
 	[[NSDistributedNotificationCenter defaultCenter] addObserver:self
@@ -205,9 +205,9 @@
 	// Fake a timer call to construct initial values
 	[self updateCPUActivityDisplay:nil];
 
-    // And hand ourself back to SystemUIServer
+	// And hand ourself back to SystemUIServer
 	NSLog(@"MenuMeterCPU loaded.");
-    return self;
+	return self;
 
 } // initWithBundle
 
@@ -227,14 +227,14 @@
 																   object:kCPUMenuUnloadNotification];
 
 	// Let super do the rest
-    [super willUnload];
+	[super willUnload];
 
 } // willUnload
 
 - (void)dealloc {
 
 	[extraView release];
-    [extraMenu release];
+	[extraMenu release];
 	[updateTimer invalidate];  // Released by the runloop
 	[ourPrefs release];
 	[cpuInfo release];
@@ -247,7 +247,7 @@
 	[userColor release];
 	[systemColor release];
 	[fgMenuThemeColor release];
-    [super dealloc];
+	[super dealloc];
 
 } // dealloc
 
@@ -269,7 +269,7 @@
 
 	// Loop by processor
 	float renderOffset = 0;
-    int cpuDisplayModePrefs = [ourPrefs cpuDisplayMode];
+	int cpuDisplayModePrefs = [ourPrefs cpuDisplayMode];
 	for (uint32_t cpuNum = 0; cpuNum < [cpuInfo numberOfCPUs]; cpuNum++) {
 
 		// Render graph if needed
@@ -340,7 +340,7 @@
 	// Loop over pixels in desired width until we're out of data
 	int renderPosition = 0;
 	float renderHeight = (float)[image size].height - 0.5f;  // Save space for baseline
- 	for (renderPosition = 0; renderPosition < [ourPrefs cpuGraphLength]; renderPosition++) {
+	for (renderPosition = 0; renderPosition < [ourPrefs cpuGraphLength]; renderPosition++) {
 		// No data at this position?
 		if (renderPosition >= [loadHistory count]) break;
 
@@ -352,15 +352,15 @@
 		}
 
 		// Get load at this position.
-        MenuMeterCPULoad *load = loadHistoryEntry[processor];
-        float system = load.system;
-        float user = load.user;
+		MenuMeterCPULoad *load = loadHistoryEntry[processor];
+		float system = load.system;
+		float user = load.user;
 		if ([ourPrefs cpuAvgAllProcs]) {
-            NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+			NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
 			for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
-                MenuMeterCPULoad *load = loadHistoryEntry[cpuNum];
-                system += load.system;
-                user += load.user;
+				MenuMeterCPULoad *load = loadHistoryEntry[cpuNum];
+				system += load.system;
+				user += load.user;
 			}
 			system /= numberOfCPUs;
 			user /= numberOfCPUs;
@@ -401,13 +401,13 @@
 	NSArray *currentLoad = [loadHistory lastObject];
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
-    MenuMeterCPULoad *load = currentLoad[processor];
-    float totalLoad = load.system + load.user;
+	MenuMeterCPULoad *load = currentLoad[processor];
+	float totalLoad = load.system + load.user;
 	if ([ourPrefs cpuAvgAllProcs]) {
-        NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+		NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
 		for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
-            MenuMeterCPULoad *load = currentLoad[cpuNum];
-            totalLoad += load.user + load.system;
+			MenuMeterCPULoad *load = currentLoad[cpuNum];
+			totalLoad += load.user + load.system;
 		}
 		totalLoad /= numberOfCPUs;
 	}
@@ -439,15 +439,15 @@
 	NSArray *currentLoad = [loadHistory lastObject];
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
-    MenuMeterCPULoad *load = currentLoad[processor];
-    float system = load.system;
-    float user = load.user;
+	MenuMeterCPULoad *load = currentLoad[processor];
+	float system = load.system;
+	float user = load.user;
 	if ([ourPrefs cpuAvgAllProcs]) {
-        NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+		NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
 		for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
-            MenuMeterCPULoad *load = currentLoad[cpuNum];
-            system += load.system;
-            user += load.user;
+			MenuMeterCPULoad *load = currentLoad[cpuNum];
+			system += load.system;
+			user += load.user;
 		}
 		system /= numberOfCPUs;
 		user /= numberOfCPUs;
@@ -486,18 +486,18 @@
 	NSArray *currentLoad = [loadHistory lastObject];
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
-    MenuMeterCPULoad *load = currentLoad[processor];
-    float system = load.system;
-    float user = load.user;
+	MenuMeterCPULoad *load = currentLoad[processor];
+	float system = load.system;
+	float user = load.user;
 	if ([ourPrefs cpuAvgAllProcs]) {
-        NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
-        for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
-            MenuMeterCPULoad *load = currentLoad[cpuNum];
-            system += load.system;
-            user += load.user;
-        }
-        system /= numberOfCPUs;
-        user /= numberOfCPUs;
+		NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+		for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
+			MenuMeterCPULoad *load = currentLoad[cpuNum];
+			system += load.system;
+			user += load.user;
+		}
+		system /= numberOfCPUs;
+		user /= numberOfCPUs;
 	}
 	if (system > 1) system = 1;
 	if (system < 0) system = 0;
@@ -581,12 +581,12 @@
 	if (!currentLoad || ([currentLoad count] < [cpuInfo numberOfCPUs])) return;
 
 	double totalLoad = 0;
-    NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
-    for (uint32_t cpuNum = 0; cpuNum < numberOfCPUs; cpuNum++) {
-        MenuMeterCPULoad *load = currentLoad[cpuNum];
-        totalLoad += load.system + load.user;
-    }
-    totalLoad /= numberOfCPUs;
+	NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+	for (uint32_t cpuNum = 0; cpuNum < numberOfCPUs; cpuNum++) {
+		MenuMeterCPULoad *load = currentLoad[cpuNum];
+		totalLoad += load.system + load.user;
+	}
+	totalLoad /= numberOfCPUs;
 	if (totalLoad > 1) totalLoad = 1;
 	if (totalLoad < 0) totalLoad = 0;
 

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -641,6 +641,9 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
+#ifdef ELCAPITAN
+    [super configDisplay:kCPUMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs cpuInterval]];
+#endif
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -807,9 +810,6 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
-#ifdef ELCAPITAN
-	[super configDisplay:kCPUMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs cpuInterval]];
-#endif
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -641,9 +641,6 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
-#ifdef ELCAPITAN
-    [super configDisplay:kCPUMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs cpuInterval]];
-#endif
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -810,6 +807,9 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
+#ifdef ELCAPITAN
+	[super configDisplay:kCPUMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs cpuInterval]];
+#endif
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -340,13 +340,15 @@
 	// Loop over pixels in desired width until we're out of data
 	int renderPosition = 0;
 	float renderHeight = (float)[image size].height - 0.5f;  // Save space for baseline
-	for (renderPosition = 0; renderPosition < [ourPrefs cpuGraphLength]; renderPosition++) {
+	int cpuGraphLength = [ourPrefs cpuGraphLength];
+	NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
+	for (renderPosition = 0; renderPosition < cpuGraphLength; renderPosition++) {
 		// No data at this position?
 		if (renderPosition >= [loadHistory count]) break;
 
 		// Grab data
 		NSArray *loadHistoryEntry = [loadHistory objectAtIndex:renderPosition];
-		if (!loadHistoryEntry || ([loadHistoryEntry count] < [cpuInfo numberOfCPUs])) {
+		if (!loadHistoryEntry || [loadHistoryEntry count] < numberOfCPUs) {
 			// Bad data, just skip
 			continue;
 		}
@@ -356,7 +358,6 @@
 		float system = load.system;
 		float user = load.user;
 		if ([ourPrefs cpuAvgAllProcs]) {
-			NSUInteger numberOfCPUs = [cpuInfo numberOfCPUs];
 			for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
 				MenuMeterCPULoad *load = loadHistoryEntry[cpuNum];
 				system += load.system;

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.h
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.h
@@ -30,6 +30,10 @@
 #import <mach/mach_error.h>
 #import "MenuMeterCPU.h"
 
+@interface MenuMeterCPULoad : NSObject
+@property(nonatomic) double system;
+@property(nonatomic) double user;
+@end
 
 @interface MenuMeterCPUStats : NSObject {
 

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.m
@@ -24,6 +24,9 @@
 #import "MenuMeterCPUStats.h"
 
 
+@implementation MenuMeterCPULoad
+@end
+
 ///////////////////////////////////////////////////////////////
 //
 //	Private methods
@@ -278,15 +281,13 @@
 		}
 		total = system + user + idle;
 
-		// Sanity
-		if (total < 1) {
-			total = 1;
-		}
+        float normalize = (total < 1) ? 1 : (1.0 / total);
 
-		[loadInfo addObject:[NSDictionary dictionaryWithObjectsAndKeys:
-								[NSNumber numberWithFloat:((float)system / (float)total)], @"system",
-								[NSNumber numberWithFloat:((float)user / (float)total)], @"user",
-								nil]];
+        MenuMeterCPULoad *load = [[MenuMeterCPULoad alloc] init];
+        load.system = system * normalize;
+        load.user = user * normalize;
+        [loadInfo addObject:load];
+        [load release];
 	}
 
 	// Copy the new data into previous

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.m
@@ -281,13 +281,13 @@
 		}
 		total = system + user + idle;
 
-        float normalize = (total < 1) ? 1 : (1.0 / total);
-
-        MenuMeterCPULoad *load = [[MenuMeterCPULoad alloc] init];
-        load.system = system * normalize;
-        load.user = user * normalize;
-        [loadInfo addObject:load];
-        [load release];
+		float normalize = (total < 1) ? 1 : (1.0 / total);
+		
+		MenuMeterCPULoad *load = [[MenuMeterCPULoad alloc] init];
+		load.system = system * normalize;
+		load.user = user * normalize;
+		[loadInfo addObject:load];
+		[load release];
 	}
 
 	// Copy the new data into previous

--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUView.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUView.m
@@ -63,8 +63,7 @@
     if (image) {
 		// Live updating even when menu is down handled by making the extra
 		// draw the background if needed.
-		if ([cpuMenuExtra isMenuDown] || 
-			([cpuMenuExtra respondsToSelector:@selector(isMenuDownForAX)] && [cpuMenuExtra isMenuDownForAX])) {
+		if (cpuMenuExtra.isMenuVisible) {
 			[cpuMenuExtra drawMenuBackground:YES];
 		}
 		// CPU image is is height - 1 to skip edge of menubar

--- a/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.h
+++ b/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.h
@@ -40,10 +40,6 @@
     MenuMeterDiskView 				*extraView;
 	// Pref object
 	MenuMeterDefaults				*ourPrefs;
-	// Are we on Panther?
-	BOOL							isPantherOrLater, isSnowLeopardOrLater;
-	// The timer
-	NSTimer							*updateTimer;
 	// Info gatherers
 	MenuMeterDiskIO					*diskIOMonitor;
 	MenuMeterDiskSpace				*diskSpaceMonitor;

--- a/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.m
+++ b/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.m
@@ -564,20 +564,22 @@
 
 	// Restart the timer
 	[updateTimer invalidate];  // Runloop releases and retains the next one
-	updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs diskInterval]
-												   target:self
-												 selector:@selector(updateDiskActivityDisplay:)
-												 userInfo:nil
-												  repeats:YES];
-	// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
-	if (isPantherOrLater) {
-		[[NSRunLoop currentRunLoop] addTimer:updateTimer
-									 forMode:NSEventTrackingRunLoopMode];
+	
+	if([ourPrefs loadBoolPref:kDiskMenuBundleID defaultValue:YES]) {
+		updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs diskInterval]
+													   target:self
+													 selector:@selector(updateDiskActivityDisplay:)
+													 userInfo:nil
+													  repeats:YES];
+		// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
+		if (isPantherOrLater) {
+			[[NSRunLoop currentRunLoop] addTimer:updateTimer
+										 forMode:NSEventTrackingRunLoopMode];
+		}
+		
+		// Flag us for redisplay
+		[extraView setNeedsDisplay:YES];
 	}
-
-	// Flag us for redisplay
-	[extraView setNeedsDisplay:YES];
-
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.m
+++ b/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.m
@@ -434,6 +434,10 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
+#ifdef ELCAPITAN
+    [super configDisplay:kDiskMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs diskInterval]];
+#endif
+
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -574,10 +578,6 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
-#ifdef ELCAPITAN
-	[super configDisplay:kDiskMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs diskInterval]];
-#endif
-	
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.m
+++ b/MenuExtras/MenuMeterDisk/MenuMeterDiskExtra.m
@@ -434,10 +434,6 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
-#ifdef ELCAPITAN
-    [super configDisplay:kDiskMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs diskInterval]];
-#endif
-
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -578,6 +574,10 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
+#ifdef ELCAPITAN
+	[super configDisplay:kDiskMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs diskInterval]];
+#endif
+	
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterDisk/MenuMeterDiskView.m
+++ b/MenuExtras/MenuMeterDisk/MenuMeterDiskView.m
@@ -63,8 +63,7 @@
     if (image) {
 		// Live updating even when menu is down handled by making the extra
 		// draw the background if needed.
-		if ([diskMenuExtra isMenuDown] || 
-			([diskMenuExtra respondsToSelector:@selector(isMenuDownForAX)] && [diskMenuExtra isMenuDownForAX])) {
+		if (diskMenuExtra.isMenuVisible) {
 			[diskMenuExtra drawMenuBackground:YES];
 		}
 		// Disk images are 22px (same height as menubar and our view)

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.h
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.h
@@ -37,10 +37,6 @@
 	// Menu Extra necessities
 	NSMenu 							*extraMenu;
     MenuMeterMemView 				*extraView;
-	// Is this Panther? Tiger?
-	BOOL							isPantherOrLater, isTigerOrLater;
-	// The timer
-	NSTimer							*updateTimer;
 	// Pref object
 	MenuMeterDefaults				*ourPrefs;
 	// Info gathers

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
@@ -883,8 +883,7 @@
 	[extraView setNeedsDisplay:YES];
 
 	// If the menu is down, update it
-	if ([self isMenuDown] || 
-		([self respondsToSelector:@selector(isMenuDownForAX)] && [self isMenuDownForAX])) {
+	if (self.isMenuVisible) {
 		[self updateMenuWhenDown];
 	}
 

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
@@ -912,6 +912,10 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
+#ifdef ELCAPITAN
+    [super configDisplay:kMemMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs memInterval]];
+#endif
+
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -1038,10 +1042,6 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
-#ifdef ELCAPITAN
-	[super configDisplay:kMemMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs memInterval]];
-#endif
-	
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
@@ -912,10 +912,6 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
-#ifdef ELCAPITAN
-    [super configDisplay:kMemMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs memInterval]];
-#endif
-
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -1042,6 +1038,10 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
+#ifdef ELCAPITAN
+	[super configDisplay:kMemMenuBundleID fromPrefs:ourPrefs withTimerInterval:[ourPrefs memInterval]];
+#endif
+	
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
@@ -1024,24 +1024,25 @@
 
 	// Restart the timer
 	[updateTimer invalidate];  // Runloop releases and retains the next one
-	updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs memInterval]
-												   target:self
-												 selector:@selector(updateMemDisplay:)
-												 userInfo:nil
-												  repeats:YES];
-	// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
-	if (isPantherOrLater) {
-		[[NSRunLoop currentRunLoop] addTimer:updateTimer
-									 forMode:NSEventTrackingRunLoopMode];
+	if([ourPrefs loadBoolPref:kMemMenuBundleID defaultValue:YES]) {
+		updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs memInterval]
+													   target:self
+													 selector:@selector(updateMemDisplay:)
+													 userInfo:nil
+													  repeats:YES];
+		// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
+		if (isPantherOrLater) {
+			[[NSRunLoop currentRunLoop] addTimer:updateTimer
+										 forMode:NSEventTrackingRunLoopMode];
+		}
+		
+		// Resize the view
+		[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
+		[self setLength:menuWidth];
+		
+		// Flag us for redisplay
+		[extraView setNeedsDisplay:YES];
 	}
-
-	// Resize the view
-	[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
-	[self setLength:menuWidth];
-
-	// Flag us for redisplay
-	[extraView setNeedsDisplay:YES];
-
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
@@ -43,7 +43,6 @@
 - (void)renderPageIndicatorIntoImage:(NSImage *)image;
 
 // Timer callbacks
-- (void)updateMemDisplay:(NSTimer *)timer;
 - (void)updateMenuWhenDown;
 
 // Prefs
@@ -94,10 +93,6 @@
 	if (!self) {
 		return nil;
 	}
-
-	// Panther and Tiger check
-	isPantherOrLater = OSIsPantherOrLater();
-	isTigerOrLater = OSIsTigerOrLater();
 
 	// Load our pref bundle, we do this as a bundle because we are a plugin
 	// to SystemUIServer and as a result cannot have the same class loaded
@@ -257,9 +252,6 @@
 	// And configure directly from prefs on first load
 	[self configFromPrefs:nil];
 
-	// Fake a timer call to config initial values
-	[self updateMemDisplay:nil];
-
     // And hand ourself back to SystemUIServer
 	NSLog(@"MenuMeterMem loaded.");
     return self;
@@ -267,10 +259,6 @@
 } // initWithBundle
 
 - (void)willUnload {
-
-	// Stop the timer
-	[updateTimer invalidate];  // Released by the runloop
-	updateTimer = nil;
 
 	// Unregister pref change notifications
 	[[NSDistributedNotificationCenter defaultCenter] removeObserver:self
@@ -291,7 +279,6 @@
 	// Release the view and menu
 	[extraView release];
     [extraMenu release];
-	[updateTimer invalidate];  // Released by the runloop
 	[ourPrefs release];
 	[memStats release];
 	[localizedStrings release];
@@ -450,20 +437,12 @@
 					[prettyIntFormatter stringForObjectValue:[currentMemStats objectForKey:@"cowfaults"]]]];
 	LiveUpdateMenuItemTitle(extraMenu, kMemVMFaultInfoMenuIndex, title);
 	// Swap count/path, Tiger swap encryptioninfo from Michael Nordmeyer (http://goodyworks.com)
-	if (isTigerOrLater && [[currentSwapStats objectForKey:@"swapencrypted"] boolValue]) {
+	if ([[currentSwapStats objectForKey:@"swapencrypted"] boolValue]) {
 		title = [NSString stringWithFormat:kMenuIndentFormat,
 					[NSString stringWithFormat:
 						(([[currentSwapStats objectForKey:@"swapcount"] unsignedIntValue] > 1) ?
 							[localizedStrings objectForKey:kMultiEncryptedSwapFormat] :
 							[localizedStrings objectForKey:kSingleEncryptedSwapFormat]),
-						[prettyIntFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapcount"]],
-						[currentSwapStats objectForKey:@"swappath"]]];
-	} else {
-		title = [NSString stringWithFormat:kMenuIndentFormat,
-					[NSString stringWithFormat:
-						(([[currentSwapStats objectForKey:@"swapcount"] unsignedIntValue] > 1) ?
-							[localizedStrings objectForKey:kMultiSwapFormat] :
-							[localizedStrings objectForKey:kSingleSwapFormat]),
 						[prettyIntFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapcount"]],
 						[currentSwapStats objectForKey:@"swappath"]]];
 	}
@@ -477,16 +456,10 @@
 					[prettyIntFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapcountpeak"]]]];
 	LiveUpdateMenuItemTitle(extraMenu, kMemSwapMaxCountInfoMenuIndex, title);
 	// Swap size, Tiger swap used path from Michael Nordmeyer (http://goodyworks.com)
-	if (isTigerOrLater) {
-		title = [NSString stringWithFormat:kMenuIndentFormat,
-			[NSString stringWithFormat:[localizedStrings objectForKey:kSwapSizeUsedFormat],
-				[memIntMBFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapsizemb"]],
-				[memIntMBFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapusedmb"]]]];
-	} else {
-		title = [NSString stringWithFormat:kMenuIndentFormat,
-					[NSString stringWithFormat:[localizedStrings objectForKey:kSwapSizeFormat],
-						[memIntMBFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapsize"]]]];
-	}
+	title = [NSString stringWithFormat:kMenuIndentFormat,
+		[NSString stringWithFormat:[localizedStrings objectForKey:kSwapSizeUsedFormat],
+			[memIntMBFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapsizemb"]],
+			[memIntMBFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapusedmb"]]]];
 	LiveUpdateMenuItemTitle(extraMenu, kMemSwapSizeInfoMenuIndex, title);
 
 } // updateMenuContent
@@ -863,7 +836,7 @@
 //
 ///////////////////////////////////////////////////////////////
 
-- (void)updateMemDisplay:(NSTimer *)timer {
+- (void)timerFired:(NSTimer *)timer {
 
 	NSDictionary *currentStats = [memStats memStats];
 	if (!currentStats) return;
@@ -878,16 +851,12 @@
 	}
 	[memHistory addObject:currentStats];
 
-	// This code used to try to avoid a redraw if nothing had changed, but
-	// the cost of a redraw is so low its a false optimization.
-	[extraView setNeedsDisplay:YES];
-
 	// If the menu is down, update it
 	if (self.isMenuVisible) {
 		[self updateMenuWhenDown];
 	}
-
-} // updateMemDisplay
+	[super timerFired:timer];
+} // timerFired
 
 - (void)updateMenuWhenDown {
 
@@ -1022,27 +991,12 @@
 		menuWidth += kMemPagingDisplayWidth + kMemPagingDisplayGapWidth;
 	}
 
-	// Restart the timer
-	[updateTimer invalidate];  // Runloop releases and retains the next one
-	if([ourPrefs loadBoolPref:kMemMenuBundleID defaultValue:YES]) {
-		updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs memInterval]
-													   target:self
-													 selector:@selector(updateMemDisplay:)
-													 userInfo:nil
-													  repeats:YES];
-		// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
-		if (isPantherOrLater) {
-			[[NSRunLoop currentRunLoop] addTimer:updateTimer
-										 forMode:NSEventTrackingRunLoopMode];
-		}
-		
-		// Resize the view
-		[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
-		[self setLength:menuWidth];
-		
-		// Flag us for redisplay
-		[extraView setNeedsDisplay:YES];
-	}
+	// Resize the view
+	[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
+	[self setLength:menuWidth];
+
+	// Force initial update
+	[self timerFired:nil];
 } // configFromPrefs
 
 @end

--- a/MenuExtras/MenuMeterMem/MenuMeterMemView.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemView.m
@@ -64,8 +64,7 @@
     if (image) {
 		// Live updating even when menu is down handled by making the extra
 		// draw the background if needed.
-		if ([memMenuExtra isMenuDown] || 
-			([memMenuExtra respondsToSelector:@selector(isMenuDownForAX)] && [memMenuExtra isMenuDownForAX])) {
+		if (memMenuExtra.isMenuVisible) {
 			[memMenuExtra drawMenuBackground:YES];
 		}
 		// Mem extra image is is height - 1 to skip edge of menubar

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.h
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.h
@@ -68,6 +68,7 @@
 	NSDictionary					*preferredInterfaceConfig;
 	// Cached dictionary of menu items that can be updated
 	NSMutableDictionary				*updateMenuItems;
+	NSFont							*throughputFont;
 
 } // MenuMeterNetExtra
 

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.h
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.h
@@ -39,11 +39,6 @@
 	// Menu Extra necessities
 	NSMenu 							*extraMenu;
     MenuMeterNetView 				*extraView;
-	// Is this Panther?
-	BOOL							isPantherOrLater,
-									isLeopardOrLater;
-	// The timer
-	NSTimer							*updateTimer;
 	// Pref object
 	MenuMeterDefaults				*ourPrefs;
 	// Info gatherers/controllers

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -281,10 +281,6 @@
 
 - (void)willUnload {
 
-	// Stop the timer
-	[updateTimer invalidate];  // Released by the runloop
-	updateTimer = nil;
-
 	// Unregister pref change notifications
 	[[NSDistributedNotificationCenter defaultCenter] removeObserver:self
 															   name:nil
@@ -303,7 +299,6 @@
 
 	[extraView release];
     [extraMenu release];
-	[updateTimer invalidate];  // Released by the runloop
 	[ourPrefs release];
 	[netConfig release];
 	[netStats release];

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -1487,10 +1487,6 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
-#ifdef ELCAPITAN
-    [super configDisplay:kNetMenuBundleID  fromPrefs:ourPrefs withTimerInterval:[ourPrefs netInterval]];
-#endif
-
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -1665,6 +1661,10 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
+#ifdef ELCAPITAN
+	[super configDisplay:kNetMenuBundleID  fromPrefs:ourPrefs withTimerInterval:[ourPrefs netInterval]];
+#endif
+	
 } // configFromPrefs
 
 ///////////////////////////////////////////////////////////////

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -1647,24 +1647,25 @@
 
 	// Restart the timer
 	[updateTimer invalidate];  // Runloop releases and retains the next one
-	updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs netInterval]
-												   target:self
-												 selector:@selector(updateNetActivityDisplay:)
-												 userInfo:nil
-												  repeats:YES];
-	// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
-	if (isPantherOrLater) {
-		[[NSRunLoop currentRunLoop] addTimer:updateTimer
-									 forMode:NSEventTrackingRunLoopMode];
+	if([ourPrefs loadBoolPref:kNetMenuBundleID defaultValue:YES]) {
+		updateTimer = [NSTimer scheduledTimerWithTimeInterval:[ourPrefs netInterval]
+													   target:self
+													 selector:@selector(updateNetActivityDisplay:)
+													 userInfo:nil
+													  repeats:YES];
+		// On newer OS versions we need to put the timer into EventTracking to update while the menus are down
+		if (isPantherOrLater) {
+			[[NSRunLoop currentRunLoop] addTimer:updateTimer
+										 forMode:NSEventTrackingRunLoopMode];
+		}
+		
+		// Resize the view
+		[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
+		[self setLength:menuWidth];
+		
+		// Flag us for redisplay
+		[extraView setNeedsDisplay:YES];
 	}
-
-	// Resize the view
-	[extraView setFrameSize:NSMakeSize(menuWidth, [extraView frame].size.height)];
-	[self setLength:menuWidth];
-
-	// Flag us for redisplay
-	[extraView setNeedsDisplay:YES];
-
 } // configFromPrefs
 
 ///////////////////////////////////////////////////////////////

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -872,7 +872,7 @@
 	// Loop over pixels in desired width until we're out of data
 	int renderPosition = 0;
 	float renderHeight = graphHeight - 0.5f;  // Save room for baseline
- 	for (renderPosition = 0; renderPosition < [ourPrefs netGraphLength]; renderPosition++) {
+	for (renderPosition = 0; renderPosition < [ourPrefs netGraphLength]; renderPosition++) {
 		// No data at this position?
 		if ((renderPosition >= [netHistoryData count]) ||
 			(renderPosition >= [netHistoryIntervals count])) break;
@@ -1104,9 +1104,9 @@
 - (void)renderThroughputIntoImage:(NSImage *)image {
 
 	// Get the primary stats
-    BOOL interfaceUp = [[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue];
 	double txValue = 0;
 	double rxValue = 0;
+	BOOL interfaceUp = [[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue];
 	if (interfaceUp) {
 		NSDictionary *primaryStats = [[netHistoryData lastObject] objectForKey:[preferredInterfaceConfig objectForKey:@"statname"]];
 		if (primaryStats) {

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -1487,6 +1487,10 @@
 ///////////////////////////////////////////////////////////////
 
 - (void)configFromPrefs:(NSNotification *)notification {
+#ifdef ELCAPITAN
+    [super configDisplay:kNetMenuBundleID  fromPrefs:ourPrefs withTimerInterval:[ourPrefs netInterval]];
+#endif
+
 	// Update prefs
 	[ourPrefs syncWithDisk];
 
@@ -1661,10 +1665,6 @@
 	// Flag us for redisplay
 	[extraView setNeedsDisplay:YES];
 
-#ifdef ELCAPITAN
-	[super configDisplay:kNetMenuBundleID  fromPrefs:ourPrefs withTimerInterval:[ourPrefs netInterval]];
-#endif
-	
 } // configFromPrefs
 
 ///////////////////////////////////////////////////////////////

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -349,14 +349,15 @@
 	// Don't render without data
 	if (![netHistoryData count]) return nil;
 
+    int netDisplayModePrefs = [ourPrefs netDisplayMode];
 	// Draw displays
-	if ([ourPrefs netDisplayMode] & kNetDisplayGraph) {
+	if (netDisplayModePrefs & kNetDisplayGraph) {
 		[self renderGraphIntoImage:currentImage];
 	}
-	if ([ourPrefs netDisplayMode] & kNetDisplayArrows) {
+	if (netDisplayModePrefs & kNetDisplayArrows) {
 		[self renderActivityIntoImage:currentImage];
 	}
-	if ([ourPrefs netDisplayMode] & kNetDisplayThroughput) {
+	if (netDisplayModePrefs & kNetDisplayThroughput) {
 		[self renderThroughputIntoImage:currentImage];
 	}
 
@@ -1103,9 +1104,10 @@
 - (void)renderThroughputIntoImage:(NSImage *)image {
 
 	// Get the primary stats
+    BOOL interfaceUp = [[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue];
 	double txValue = 0;
 	double rxValue = 0;
-	if ([[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue]) {
+	if (interfaceUp) {
 		NSDictionary *primaryStats = [[netHistoryData lastObject] objectForKey:[preferredInterfaceConfig objectForKey:@"statname"]];
 		if (primaryStats) {
 			txValue = [[primaryStats objectForKey:@"deltaout"] doubleValue];
@@ -1128,7 +1130,7 @@
 													attributes:[NSDictionary dictionaryWithObjectsAndKeys:
 																	[NSFont systemFontOfSize:9.5f],
 																	NSFontAttributeName,
-																	([[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue] ? txColor : inactiveColor),
+																	interfaceUp ? txColor : inactiveColor,
 																	NSForegroundColorAttributeName,
 																	nil]] autorelease];
 	NSAttributedString *renderRxString = [[[NSAttributedString alloc]
@@ -1136,7 +1138,7 @@
 													attributes:[NSDictionary dictionaryWithObjectsAndKeys:
 																	[NSFont systemFontOfSize:9.5f],
 																	NSFontAttributeName,
-																	([[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue] ? rxColor : inactiveColor),
+																	interfaceUp ? rxColor : inactiveColor,
 																	NSForegroundColorAttributeName,
 																	nil]] autorelease];
 
@@ -1151,7 +1153,7 @@
 		if ([ourPrefs netDisplayMode] & kNetDisplayArrows) {
 			labelOffset += kNetArrowDisplayWidth + kNetDisplayGapWidth;
 		}
-		if ([[preferredInterfaceConfig objectForKey:@"interfaceup"] boolValue]) {
+		if (interfaceUp) {
 			[throughputLabel compositeToPoint:NSMakePoint(labelOffset, 0) operation:NSCompositeSourceOver];
 		} else {
 			[inactiveThroughputLabel compositeToPoint:NSMakePoint(labelOffset, 0) operation:NSCompositeSourceOver];
@@ -1214,7 +1216,7 @@
 	[extraView setNeedsDisplay:YES];
 
 	// If the menu is down force it to update
-	if ([self isMenuDown]) {
+	if (self.isMenuVisible) {
 		[self updateMenuWhenDown];
 	}
 

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -173,6 +173,8 @@
 	}
     [self setView:extraView];
 
+	throughputFont = [[NSFont systemFontOfSize:9.5f] retain];
+
 	// Localizable strings
 	localizedStrings = [[NSDictionary dictionaryWithObjectsAndKeys:
 							[[NSBundle bundleForClass:[self class]] localizedStringForKey:kTxLabel value:nil table:nil],
@@ -329,6 +331,7 @@
 	[inactiveThroughputLabel release];
 	[preferredInterfaceConfig release];
 	[updateMenuItems release];
+	[throughputFont release];
     [super dealloc];
 
 } // dealloc
@@ -1123,12 +1126,13 @@
 	if (!sampleIntervalNum && ([sampleIntervalNum doubleValue] > 0)) {
 		sampleInterval = [sampleIntervalNum doubleValue];
 	}
+	
 	NSString *txString = [self menubarThroughputStringForBytes:txValue inInterval:sampleInterval];
 	NSString *rxString = [self menubarThroughputStringForBytes:rxValue inInterval:sampleInterval];
 	NSAttributedString *renderTxString = [[[NSAttributedString alloc]
 												initWithString:txString
 													attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-																	[NSFont systemFontOfSize:9.5f],
+																	throughputFont,
 																	NSFontAttributeName,
 																	interfaceUp ? txColor : inactiveColor,
 																	NSForegroundColorAttributeName,
@@ -1136,7 +1140,7 @@
 	NSAttributedString *renderRxString = [[[NSAttributedString alloc]
 												initWithString:rxString
 													attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-																	[NSFont systemFontOfSize:9.5f],
+																	throughputFont,
 																	NSFontAttributeName,
 																	interfaceUp ? rxColor : inactiveColor,
 																	NSForegroundColorAttributeName,
@@ -1533,13 +1537,13 @@
 	NSAttributedString *renderTxString = [[[NSAttributedString alloc]
 											initWithString:[localizedStrings objectForKey:kTxLabel]
 												attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-																[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+																throughputFont, NSFontAttributeName,
 																txColor, NSForegroundColorAttributeName,
 																nil]] autorelease];
 	NSAttributedString *renderRxString = [[[NSAttributedString alloc]
 											initWithString:[localizedStrings objectForKey:kRxLabel]
 												attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-																[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+																throughputFont, NSFontAttributeName,
 																rxColor, NSForegroundColorAttributeName,
 																nil]] autorelease];
 	if ([renderTxString size].width > [renderRxString size].width) {
@@ -1562,13 +1566,13 @@
 	renderTxString = [[[NSAttributedString alloc]
 						initWithString:[localizedStrings objectForKey:kTxLabel]
 							attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-											[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+											throughputFont, NSFontAttributeName,
 											inactiveColor, NSForegroundColorAttributeName,
 											nil]] autorelease];
 	renderRxString = [[[NSAttributedString alloc]
 						initWithString:[localizedStrings objectForKey:kRxLabel]
 							attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-											[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+											throughputFont, NSFontAttributeName,
 											inactiveColor, NSForegroundColorAttributeName,
 											nil]] autorelease];
 	[inactiveThroughputLabel lockFocus];
@@ -1602,7 +1606,7 @@
 												initWithString:[NSString stringWithFormat:@"99.9%@",
 																	[localizedStrings objectForKey:kBytePerSecondLabel]]
 													attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-																	[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+																	throughputFont, NSFontAttributeName,
 																	nil]] autorelease];
 		if ([throughString size].width > suffixMaxWidth) {
 			suffixMaxWidth = (float)[throughString size].width;
@@ -1611,7 +1615,7 @@
 							initWithString:[NSString stringWithFormat:@"99.9%@",
 												[localizedStrings objectForKey:kKBPerSecondLabel]]
 								attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-												[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+												throughputFont, NSFontAttributeName,
 												nil]] autorelease];
 		if ([throughString size].width > suffixMaxWidth) {
 			suffixMaxWidth = (float)[throughString size].width;
@@ -1620,7 +1624,7 @@
 							initWithString:[NSString stringWithFormat:@"99.9%@",
 												[localizedStrings objectForKey:kMBPerSecondLabel]]
 								attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-												[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+												throughputFont, NSFontAttributeName,
 												nil]] autorelease];
 		if ([throughString size].width > suffixMaxWidth) {
 			suffixMaxWidth = (float)[throughString size].width;
@@ -1629,7 +1633,7 @@
 							initWithString:[NSString stringWithFormat:@"99.9%@",
 												[localizedStrings objectForKey:kGBPerSecondLabel]]
 								attributes:[NSDictionary dictionaryWithObjectsAndKeys:
-												[NSFont systemFontOfSize:9.5f], NSFontAttributeName,
+												throughputFont, NSFontAttributeName,
 												nil]] autorelease];
 		if ([throughString size].width > suffixMaxWidth) {
 			suffixMaxWidth = (float)[throughString size].width;

--- a/MenuExtras/MenuMeterNet/MenuMeterNetStats.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetStats.m
@@ -113,10 +113,7 @@
 			continue;
 		}
 		// Build the interface name to string so we can key off it
-		// (using NSData here because initWithBytes is 10.3 and later)
-		NSString *interfaceName = [[[NSString alloc]
-										initWithData:[NSData dataWithBytes:sdl->sdl_data length:sdl->sdl_nlen]
-									encoding:NSASCIIStringEncoding] autorelease];
+		NSString *interfaceName = [[NSString alloc] initWithBytes:sdl->sdl_data length:sdl->sdl_nlen encoding:NSASCIIStringEncoding];
 		if (!interfaceName) {
 			currentData += ifmsg->ifm_msglen;
 			continue;

--- a/MenuExtras/MenuMeterNet/MenuMeterNetView.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetView.m
@@ -63,8 +63,7 @@
     if (image) {
 		// Live updating even when menu is down handled by making the extra
 		// draw the background if needed.
-		if ([netMenuExtra isMenuDown] || 
-			([netMenuExtra respondsToSelector:@selector(isMenuDownForAX)] && [netMenuExtra isMenuDownForAX])) {
+		if (netMenuExtra.isMenuVisible) {
 			[netMenuExtra drawMenuBackground:YES];
 		}
 		// Net image is is height - 1 to skip edge of menubar

--- a/MenuMetersMenuExtraBase.h
+++ b/MenuMetersMenuExtraBase.h
@@ -15,7 +15,6 @@
     NSStatusItem*statusItem;
     NSTimer*timer;
 }
--(instancetype)initWithBundle:(NSBundle*)bundle;
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval;
 
 @property(nonatomic, readonly) BOOL isMenuVisible;

--- a/MenuMetersMenuExtraBase.h
+++ b/MenuMetersMenuExtraBase.h
@@ -12,10 +12,11 @@
 
 @interface MenuMetersMenuExtraBase : NSMenuExtra <NSMenuDelegate>
 {
-    NSStatusItem*statusItem;
-    NSTimer*timer;
+    NSStatusItem* statusItem;
+    NSTimer* updateTimer;
 }
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval;
+- (void)timerFired:(id)timer;
 
 @property(nonatomic, readonly) BOOL isMenuVisible;
 @end

--- a/MenuMetersMenuExtraBase.h
+++ b/MenuMetersMenuExtraBase.h
@@ -10,13 +10,15 @@
 #import "AppleUndocumented.h"
 #import "MenuMeterDefaults.h"
 
-@interface MenuMetersMenuExtraBase : NSMenuExtra
+@interface MenuMetersMenuExtraBase : NSMenuExtra <NSMenuDelegate>
 {
     NSStatusItem*statusItem;
     NSTimer*timer;
 }
 -(instancetype)initWithBundle:(NSBundle*)bundle;
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval;
+
+@property(nonatomic, readonly) BOOL isMenuVisible;
 @end
 
 #define NSMenuExtra MenuMetersMenuExtraBase

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -26,7 +26,7 @@
     
     NSImage *image = self.image;
     [canvas lockFocus];
-    [image drawAtPoint:CGPointZero fromRect:(CGRect) {.size = image.size} operation:NSCompositingOperationCopy fraction:1.0];
+    [image drawAtPoint:CGPointZero fromRect:(CGRect) {.size = image.size} operation:NSCompositeCopy fraction:1.0];
     [canvas unlockFocus];
     
     if (canvas != oldCanvas) {

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -8,6 +8,8 @@
 
 #import "MenuMetersMenuExtraBase.h"
 
+static const int STATUS_BUTTON_PADDING = 8;
+
 @implementation MenuMetersMenuExtraBase
 -(instancetype)initWithBundle:(NSBundle*)bundle
 {
@@ -25,7 +27,7 @@
             [[NSStatusBar systemStatusBar] removeStatusItem:statusItem];
         }
 
-        statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:self.length];
+        statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:self.length+STATUS_BUTTON_PADDING];
         statusItem.menu = self.menu;
         statusItem.menu.delegate = self;
 

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -16,10 +16,6 @@
 }
 -(void)timerFired:(id)notused
 {
-//    if(_isMenuVisible) {
-//        statusItem.menu = self.menu;
-//        statusItem.menu.delegate = self;
-//    }
     NSImage* canvas=[[NSImage alloc] initWithSize:NSMakeSize(self.length, self.view.frame.size.height)];
     [canvas lockFocus];
     [self.view drawRect:NSMakeRect(0, 0, canvas.size.width, canvas.size.height)];

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -16,8 +16,11 @@
 }
 -(void)timerFired:(id)notused
 {
-    statusItem.menu=self.menu;
-    NSImage*canvas=[[NSImage alloc] initWithSize:NSMakeSize(self.length, self.view.frame.size.height)];
+//    if(_isMenuVisible) {
+//        statusItem.menu = self.menu;
+//        statusItem.menu.delegate = self;
+//    }
+    NSImage* canvas=[[NSImage alloc] initWithSize:NSMakeSize(self.length, self.view.frame.size.height)];
     [canvas lockFocus];
     [self.view drawRect:NSMakeRect(0, 0, canvas.size.width, canvas.size.height)];
     [canvas unlockFocus];
@@ -28,6 +31,8 @@
     if([ourPrefs loadBoolPref:bundleID defaultValue:YES]){
         if(!statusItem){
             statusItem=[[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
+            statusItem.menu = self.menu;
+            statusItem.menu.delegate = self;
         }
         [timer invalidate];
         timer=[NSTimer timerWithTimeInterval:interval target:self selector:@selector(timerFired:) userInfo:nil repeats:YES];
@@ -39,4 +44,19 @@
         statusItem=nil;
     }
 }
+
+#pragma mark NSMenuDelegate
+- (void)menuNeedsUpdate:(NSMenu*)menu {
+    statusItem.menu = self.menu;
+    statusItem.menu.delegate = self;
+}
+
+- (void)menuWillOpen:(NSMenu *)menu {
+    _isMenuVisible = YES;
+}
+
+- (void)menuDidClose:(NSMenu *)menu {
+    _isMenuVisible = NO;
+}
+
 @end

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -14,6 +14,11 @@
     self=[super initWithBundle:bundle];
     return self;
 }
+-(void)willUnload {
+    [updateTimer invalidate];
+    updateTimer = nil;
+    [super willUnload];
+}
 -(void)timerFired:(id)notused
 {
     NSImage *oldCanvas = statusItem.button.image;
@@ -43,12 +48,12 @@
             statusItem.menu = self.menu;
             statusItem.menu.delegate = self;
         }
-        [timer invalidate];
-        timer=[NSTimer timerWithTimeInterval:interval target:self selector:@selector(timerFired:) userInfo:nil repeats:YES];
-        [timer setTolerance:.2*interval];
-        [[NSRunLoop currentRunLoop] addTimer:timer forMode:NSRunLoopCommonModes];
+        [updateTimer invalidate];
+        updateTimer=[NSTimer timerWithTimeInterval:interval target:self selector:@selector(timerFired:) userInfo:nil repeats:YES];
+        [updateTimer setTolerance:.2*interval];
+        [[NSRunLoop currentRunLoop] addTimer:updateTimer forMode:NSRunLoopCommonModes];
     }else if(![ourPrefs loadBoolPref:bundleID defaultValue:YES] && statusItem){
-        [timer invalidate];
+        [updateTimer invalidate];
         [[NSStatusBar systemStatusBar] removeStatusItem:statusItem];
         statusItem=nil;
     }

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -9,18 +9,9 @@
 #import "MenuMetersMenuExtraBase.h"
 
 @implementation MenuMetersMenuExtraBase
--(instancetype)initWithBundle:(NSBundle*)bundle
-{
-    self=[super initWithBundle:bundle];
-    return self;
-}
 -(void)timerFired:(id)notused
 {
-    NSImage* canvas=[[NSImage alloc] initWithSize:NSMakeSize(self.length, self.view.frame.size.height)];
-    [canvas lockFocus];
-    [self.view drawRect:NSMakeRect(0, 0, canvas.size.width, canvas.size.height)];
-    [canvas unlockFocus];
-    statusItem.button.image=canvas;
+    statusItem.button.image=[self image];
 }
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval
 {

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -9,9 +9,31 @@
 #import "MenuMetersMenuExtraBase.h"
 
 @implementation MenuMetersMenuExtraBase
+-(instancetype)initWithBundle:(NSBundle*)bundle
+{
+    self=[super initWithBundle:bundle];
+    return self;
+}
 -(void)timerFired:(id)notused
 {
-    statusItem.button.image=[self image];
+    NSImage *oldCanvas = statusItem.button.image;
+    NSImage *canvas = oldCanvas;
+    NSSize imageSize = NSMakeSize(self.length, self.view.frame.size.height);
+    NSSize oldImageSize = canvas.size;
+    if (imageSize.width != oldImageSize.width || imageSize.height != oldImageSize.height) {
+        canvas = [[NSImage alloc] initWithSize:imageSize];
+    }
+    
+    NSImage *image = self.image;
+    [canvas lockFocus];
+    [image drawAtPoint:CGPointZero fromRect:(CGRect) {.size = image.size} operation:NSCompositingOperationCopy fraction:1.0];
+    [canvas unlockFocus];
+    
+    if (canvas != oldCanvas) {
+        statusItem.button.image = canvas;
+    } else {
+        [statusItem.button setNeedsDisplay];
+    }
 }
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval
 {

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -32,7 +32,7 @@
     if (canvas != oldCanvas) {
         statusItem.button.image = canvas;
     } else {
-        [statusItem.button setNeedsDisplay];
+        [statusItem.button displayRectIgnoringOpacity:statusItem.button.bounds];
     }
 }
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -16,33 +16,19 @@
 }
 -(void)timerFired:(id)notused
 {
-    NSImage *oldCanvas = statusItem.button.image;
-    NSImage *canvas = oldCanvas;
-    NSSize imageSize = NSMakeSize(self.length, self.view.frame.size.height);
-    NSSize oldImageSize = canvas.size;
-    if (imageSize.width != oldImageSize.width || imageSize.height != oldImageSize.height) {
-        canvas = [[NSImage alloc] initWithSize:imageSize];
-    }
-    
-    NSImage *image = self.image;
-    [canvas lockFocus];
-    [image drawAtPoint:CGPointZero fromRect:(CGRect) {.size = image.size} operation:NSCompositingOperationCopy fraction:1.0];
-    [canvas unlockFocus];
-    
-    if (canvas != oldCanvas) {
-        statusItem.button.image = canvas;
-    } else {
-        [statusItem.button setNeedsDisplay];
-    }
+    statusItem.button.image = self.image;
 }
 - (void)configDisplay:(NSString*)bundleID fromPrefs:(MenuMeterDefaults*)ourPrefs withTimerInterval:(NSTimeInterval)interval
 {
     if([ourPrefs loadBoolPref:bundleID defaultValue:YES]){
-        if(!statusItem){
-            statusItem=[[NSStatusBar systemStatusBar] statusItemWithLength:NSVariableStatusItemLength];
-            statusItem.menu = self.menu;
-            statusItem.menu.delegate = self;
+        if (statusItem) {
+            [[NSStatusBar systemStatusBar] removeStatusItem:statusItem];
         }
+
+        statusItem = [[NSStatusBar systemStatusBar] statusItemWithLength:self.length];
+        statusItem.menu = self.menu;
+        statusItem.menu.delegate = self;
+
         [timer invalidate];
         timer=[NSTimer timerWithTimeInterval:interval target:self selector:@selector(timerFired:) userInfo:nil repeats:YES];
         [timer setTolerance:.2*interval];

--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -46,12 +46,10 @@
     statusItem.menu = self.menu;
     statusItem.menu.delegate = self;
 }
-
-- (void)menuWillOpen:(NSMenu *)menu {
+- (void)menuWillOpen:(NSMenu*)menu {
     _isMenuVisible = YES;
 }
-
-- (void)menuDidClose:(NSMenu *)menu {
+- (void)menuDidClose:(NSMenu*)menu {
     _isMenuVisible = NO;
 }
 


### PR DESCRIPTION
MenuMeters is NOT a huge CPU hog (sitting around 1% on my activity monitor).

But it's an app that I have running 100% of the time, and any reduction in CPU can't be a bad thing for battery life.

This pull request:
1. Reduces the number of transient memory allocations by ~60%
2. Reduces CPU/energy usage by ~50%

It achieves this by:
1. Using a custom class for storing system/user CPU times, instead of a generic NSDictionary
2. Using the convenience preferences accessors introduced in 10.10 (eg. CFPreferencesGetAppIntegerValue)
3. Only updating menus when they're about to be shown, or visible. (I have a lot of network interfaces due to virtual machines, and updating a menu that fills the full screen every second when it won't be shown is a huge waste)
4. Caching the throughput font in network activity
5. Factoring out some function calls to variables in inner loops.
6. Avoiding a full status bar re-layout by changing the NSImage that the button uses, and telling it to display. (tried-and-rejected: using a fixed width menu item instead.. not as performant)
7. Removing duplicate timers in the Base and each extra, and instead use a single timer per extra.