### PR TITLE
Use plural form of format strings for 0 items

### DIFF
--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -123,7 +123,7 @@
 	NSMenuItem *menuItem = nil;
 
 	// Add processor info which never changes
-    if ([cpuInfo numberOfCPUs] > 1) {
+    if ([cpuInfo numberOfCPUs] != 1) {
 		menuItem = (NSMenuItem *)[extraMenu addItemWithTitle:[bundle localizedStringForKey:kMultiProcessorTitle value:nil table:nil]
 													  action:nil
 											   keyEquivalent:@""];

--- a/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
+++ b/MenuExtras/MenuMeterMem/MenuMeterMemExtra.m
@@ -415,7 +415,7 @@
 	if ([[currentSwapStats objectForKey:@"swapencrypted"] boolValue]) {
 		title = [NSString stringWithFormat:kMenuIndentFormat,
 					[NSString stringWithFormat:
-						(([[currentSwapStats objectForKey:@"swapcount"] unsignedIntValue] > 1) ?
+						(([[currentSwapStats objectForKey:@"swapcount"] unsignedIntValue] != 1) ?
 							[localizedStrings objectForKey:kMultiEncryptedSwapFormat] :
 							[localizedStrings objectForKey:kSingleEncryptedSwapFormat]),
 						[prettyIntFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapcount"]],
@@ -425,7 +425,7 @@
 	// Swap max
 	title = [NSString stringWithFormat:kMenuIndentFormat,
 				[NSString stringWithFormat:
-					(([[currentSwapStats objectForKey:@"swapcountpeak"] unsignedIntValue] > 1) ?
+					(([[currentSwapStats objectForKey:@"swapcountpeak"] unsignedIntValue] != 1) ?
 						[localizedStrings objectForKey:kMaxMultiSwapFormat] :
 						[localizedStrings objectForKey:kMaxSingleSwapFormat]),
 					[prettyIntFormatter stringForObjectValue:[currentSwapStats objectForKey:@"swapcountpeak"]]]];


### PR DESCRIPTION
In all languages I am aware of, including English,
singular is only used for N==1, not for N==0.