### PR TITLE
Make two hyperthreading-related strings localizable

### DIFF
--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUStats.m
@@ -48,6 +48,8 @@
 #define kTaskThreadFormat					@"%d tasks, %d threads"
 #define kLoadAverageFormat					@"%@, %@, %@"
 #define kNoInfoErrorMessage					@"No info available"
+#define kHyperThreadsPerCoreFormat			@" (%@ hyperthreads per core)"
+#define kPhysicalCoresFormat				@"%@%@ physical cores"
 
 
 ///////////////////////////////////////////////////////////////
@@ -157,6 +159,10 @@ uint32_t packageCount;
 							kLoadAverageFormat,
 							[[NSBundle bundleForClass:[self class]] localizedStringForKey:kNoInfoErrorMessage value:nil table:nil],
 							kNoInfoErrorMessage,
+							[[NSBundle bundleForClass:[self class]] localizedStringForKey:kHyperThreadsPerCoreFormat value:nil table:nil],
+							kHyperThreadsPerCoreFormat,
+							[[NSBundle bundleForClass:[self class]] localizedStringForKey:kPhysicalCoresFormat value:nil table:nil],
+							kPhysicalCoresFormat,
 							nil];
 	if (!localizedStrings) {
 		return nil;
@@ -212,9 +218,9 @@ uint32_t packageCount;
 - (NSString *)coreDescription {
     NSString*hyperinfo=@"";
     if(cpuCount!=coreCount){
-        hyperinfo=[NSString stringWithFormat:@" (%@ hyperthreads per core)",@(cpuCount/coreCount)];
+        hyperinfo=[NSString stringWithFormat:[localizedStrings objectForKey:kHyperThreadsPerCoreFormat],@(cpuCount/coreCount)];
     }
-    return [NSString stringWithFormat:@"%@%@ physical cores%@",[self packages],@(coreCount/packageCount),hyperinfo];
+    return [NSString stringWithFormat:@"%@%@", [NSString stringWithFormat:[localizedStrings objectForKey:kPhysicalCoresFormat],[self packages],@(coreCount/packageCount)],hyperinfo];
 } // coreDescription
 
 ///////////////////////////////////////////////////////////////

--- a/MenuMetersApp/Base.lproj/Localizable.strings
+++ b/MenuMetersApp/Base.lproj/Localizable.strings
@@ -34,6 +34,10 @@
 // Format string for tasks and threads
 "%d tasks, %d threads" = "%1$d tasks, %2$d threads";
 
+// Core count / hyperthreading format strings
+" (%@ hyperthreads per core)" = " (%@ hyperthreads per core)";
+"%@%@ physical cores" = "%@%@ physical cores";
+
 // Load average title
 "Load Average (1m, 5m, 15m):" = "Load Average (1m, 5m, 15m):";
 

--- a/MenuMetersApp/fi.lproj/Localizable.strings
+++ b/MenuMetersApp/fi.lproj/Localizable.strings
@@ -34,6 +34,10 @@
 // Format string for tasks and threads
 "%d tasks, %d threads" = "%1$d tehtävää, %2$d säiettä";
 
+// Core count / hyperthreading format strings
+" (%@ hyperthreads per core)" = " (%@ hypersäiettä/ydin)";
+"%@%@ physical cores" = "%@%@ fyysistä ydintä";
+
 // Load average title
 "Load Average (1m, 5m, 15m):" = "Keskikuorma (1 min, 5 min, 15 min):";
 


### PR DESCRIPTION
One more pull request.

I have no idea whether the Localizable.strings files for other languages should also be updated when adding new localizable strings. In any case, this commit only adds them to Base and fi.