### PR TITLE
Fix average CPU load computation (don't skip the zero-indexed/first CPU's data)

### DIFF
--- a/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
+++ b/MenuExtras/MenuMeterCPU/MenuMeterCPUExtra.m
@@ -902,7 +902,7 @@
     }else{
         double s=0,u=0;
         int numberOfCPUs = [cpuInfo numberOfCPUs];
-        for (uint32_t cpuNum = 1; cpuNum < numberOfCPUs; cpuNum++) {
+        for (uint32_t cpuNum = 0; cpuNum < numberOfCPUs; cpuNum++) {
                 MenuMeterCPULoad *load = currentLoad[cpuNum];
             s+=load.system;
             u+=load.user;


### PR DESCRIPTION
I noticed that my 6-core iMac, when CPU pegged; only displays 83% on MenuMeters. Thought I would see if I could fix it. 

Upon debugging, the issue is simply that we start at index = 1 in the currentLoad array. Our for loop terminates when cpuNum == numberofCPUs, so we won't array index out of bound, we'll just silently drop the first CPU's data; but still divide by the full number of processors to come up with the average--thus, voilà, 5/6 aka 83% load. 

This looks like the only place in the file where we start at index = 1; and it appears to date from the original 1.8.1 code (where there were multiple copies of this buggy loop; which were condensed into getCPULoadForCPU later). 

This is my very first time using Xcode/Objective-C and contributing to an open source project (I'm a Microsoft engineer and my day job uses Visual Studio and C#); apologies if I got something wrong. 

This should fix #142 (checking, the sum of all cores computation is implemented by multiplying the average by the number of cores, and it is also fixed).