### PR TITLE
Do not display link speed label if we cannot determine it. Makes #155 less bad.

### DIFF
--- a/MenuExtras/MenuMeterNet/MenuMeterNetConfig.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetConfig.m
@@ -31,7 +31,7 @@
 ///////////////////////////////////////////////////////////////
 
 // Speed defines
-#define kInterfaceDefaultSpeed 			10000000
+#define kInterfaceDefaultSpeed 			-1
 #define kModemInterfaceDefaultSpeed		56000
 
 @interface MenuMeterNetConfig (PrivateMethods)
@@ -614,15 +614,12 @@ static void scChangeCallback(SCDynamicStoreRef store, CFArrayRef changedKeys, vo
 		return [NSNumber numberWithLong:kInterfaceDefaultSpeed];
 	}
 	NSNumber *linkSpeed = (NSNumber *)CFBridgingRelease(IORegistryEntryCreateCFProperty(controllerService,
-																	  CFSTR(kIOLinkSpeed),
-																	  kCFAllocatorDefault,
-																	  kNilOptions));
+																						CFSTR(kIOLinkSpeed),
+																						kCFAllocatorDefault,
+																						kNilOptions));
 	IOObjectRelease(controllerService);
 	IOObjectRelease(regEntry);
 	IOObjectRelease(iterator);
-	if (linkSpeed) {
-        return linkSpeed;
-	}
 	if (linkSpeed && ([linkSpeed unsignedLongLongValue] > 0)) {
 		return linkSpeed;
 	} else {

--- a/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
+++ b/MenuExtras/MenuMeterNet/MenuMeterNetExtra.m
@@ -367,7 +367,7 @@
 - (NSMenu *)menu {
 
 	// New cache
-	updateMenuItems = [NSMutableDictionary dictionary];//
+	updateMenuItems = [NSMutableDictionary dictionary];
 
 	// Empty the menu
 	while ([extraMenu numberOfItems]) {
@@ -407,7 +407,9 @@
 			
             // Calc speed
 			if ([details objectForKey:@"linkspeed"] && isActiveInterface) {
-				if ([[details objectForKey:@"linkspeed"] doubleValue] > 1000000000) {
+				if ([[details objectForKey:@"linkspeed"] doubleValue] < 0) {
+					speed = nil;
+				} else if ([[details objectForKey:@"linkspeed"] doubleValue] > 1000000000) {
 					speed = [NSString stringWithFormat:@" %.0f %@",
 								([[details objectForKey:@"linkspeed"] doubleValue] / 1000000000),
 								[localizedStrings objectForKey:kGbpsLabel]];


### PR DESCRIPTION
This does not fix link speed display in the network dropdown, but it gives up on guessing, and will not pass "0" through to the frontend since that's obviously bogus.

In effect, I am seeing just "Ethernet" for my wired interfaces, and the correct link speed (currently 780Mbps) for my built-in 802.11ac interface.