### PR TITLE
Retain transparency during color tint

### DIFF
--- a/MenuMetersMenuExtraBase.m
+++ b/MenuMetersMenuExtraBase.m
@@ -19,7 +19,7 @@
 @implementation MenuMetersMenuExtraBase
 -(NSColor*)colorByAdjustingForLightDark:(NSColor*)c
 {
-    return [c blendedColorWithFraction:[[NSUserDefaults standardUserDefaults] floatForKey:@"tintPercentage"]/100  ofColor:self.isDark?[NSColor whiteColor]:[NSColor blackColor]];
+    return [c blendedColorWithFraction:[[NSUserDefaults standardUserDefaults] floatForKey:@"tintPercentage"]/100  ofColor:self.isDark?[[NSColor whiteColor] colorWithAlphaComponent:[c alphaComponent]]:[[NSColor blackColor] colorWithAlphaComponent:[c alphaComponent]]];
 }
 -(instancetype)initWithBundleID:(NSString*)bundleID
 {


### PR DESCRIPTION
Now that user-selected colors can have transparency, it's possible to create nice monochrome graphs using opacity instead of different colors. The Memory Usage Chart and CPU vertical bars are two examples of color-based display. However, the "color tint" feature blends transparent colors toward 100% opaque white/black, so any distinctions in these color charts are lost as you reach the far end of the slider. For example, in 2.1.1 with "color tint" fully on, my Memory Usage Chart is always a 99% full white circle, with no way to see the amount of active vs. inactive memory.

This patch retains the amount of transparency when applying the color tint, so one can build nice grayscale charts with appropriate contrast, no matter what the current menu colors are.