### PR TITLE
M1 pro/max fix

### DIFF
--- a/hardware_reader/applesilicon_hardware_reader.m
+++ b/hardware_reader/applesilicon_hardware_reader.m
@@ -72,7 +72,9 @@ NSDictionary*AppleSiliconTemperatureDictionary(void)
             double temp = IOHIDEventGetFloatValue(event, IOHIDEventFieldBase(kIOHIDEventTypeTemperature));
             dict[name]=@(temp);
         }
-        CFRelease(event);
+        if (event) {
+            CFRelease(event);
+        }
     }
     
     CFRelease(matchingsrvs);


### PR DESCRIPTION
When running MenuMeters on an M1 Max (I believe M1 Pro suffers from the same problem), it immediately crashes on start. The reason is simple: We're releasing a NULL pointer. This simple fix makes MenuMeters work on M1 Max for me.